### PR TITLE
Upgraded to liquibase latest stable version (3.0.5).

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,6 @@ version := "0.5"
 
 crossScalaVersions := Seq("2.9.2", "2.10.0")
 
-libraryDependencies += "org.liquibase" % "liquibase-core" % "2.0.5"
+libraryDependencies += "org.liquibase" % "liquibase-core" % "3.0.5"
 
 publishTo := Some(Resolver.file("bigtoast.github.com", file(Path.userHome + "/Projects/BigToast/bigtoast.github.com/repo")))

--- a/src/main/scala/LiquibasePlugin.scala
+++ b/src/main/scala/LiquibasePlugin.scala
@@ -60,7 +60,7 @@ object LiquibasePlugin extends Plugin {
   liquibaseDatabase <<= (liquibaseUrl, liquibaseUsername, liquibasePassword, liquibaseDriver, liquibaseDefaultSchemaName, fullClasspath in Runtime ) map {
     (url :String, uname :String, pass :String, driver :String, schemaName :String, cpath ) =>
       //CommandLineUtils.createDatabaseObject( ClasspathUtilities.toLoader(cpath.map(_.data)) ,url, uname, pass, driver, schemaName, null,null)
-      CommandLineUtils.createDatabaseObject( ClasspathUtilities.toLoader(cpath.map(_.data)) ,url, uname, pass, driver, null, null,null)
+      CommandLineUtils.createDatabaseObject( ClasspathUtilities.toLoader(cpath.map(_.data)) ,url, uname, pass, driver, null, null, false, false, null, null, null,null)
   },
 
   liquibase <<= ( liquibaseChangelog, liquibaseDatabase ) map {
@@ -135,7 +135,7 @@ object LiquibasePlugin extends Plugin {
 
     liquibaseGenerateChangelog <<= (streams, liquibase, liquibaseChangelog, liquibaseDefaultSchemaName, baseDirectory) map { (out, lbase, clog, sname, bdir) =>
       //CommandLineUtils.doGenerateChangeLog(clog, lbase.getDatabase(), sname, null,null,null, bdir / "src" / "main" / "migrations" absolutePath )
-      CommandLineUtils.doGenerateChangeLog(clog, lbase.getDatabase(), null, null,null,null, bdir / "src" / "main" / "migrations" absolutePath )
+      CommandLineUtils.doGenerateChangeLog(clog, lbase.getDatabase(), null, null, null, null, null, bdir / "src" / "main" / "migrations" absolutePath, null)
     },
 
     liquibaseChangelogSyncSql <<= (streams, liquibase ) map { ( out, lbase) =>


### PR DESCRIPTION
There was quite a lot of bugs impacting us with liquibase 2.0.5. Upgraded to latest version 3.0.5 fixed them all.

Thanks,

Julien
