### PR TITLE
Update to Liquibase 3.3.0; add support for changelog schema and catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,39 @@ Or if you are using a build object extending from Build:
 
         </td></tr>
         <tr>
-                <td> <b>liquibaseDefaultSchemaName</b> </td>
-                <td>Default schema name for the db if it isn't defined in the uri. This defaults to null.</td>
+                <td> <b>liquibaseChangelogCatalog</b> </td>
+                <td>Default catalog name for the changelog tables. This defaults to None.</td>
         </tr>
         <tr><td></td><td>
 
-            liquibaseDefaultSchemaName := "dbname"
+            liquibaseChangelogCatalog := Some("my_catalog")
+
+        </td></tr>
+        <tr>
+                <td> <b>liquibaseChangelogSchemaName</b> </td>
+                <td>Default schema name for the changelog tables. This defaults to None.</td>
+        </tr>
+        <tr><td></td><td>
+
+            liquibaseChangelogSchemaName := Some("my_schema")
+
+        </td></tr>
+        <tr>
+                <td> <b>liquibaseDefaultCatalog</b> </td>
+                <td>Default catalog name for the db if it isn't defined in the uri. This defaults to None.</td>
+        </tr>
+        <tr><td></td><td>
+
+            liquibaseDefaultCatalog := Some("my_catalog")
+
+        </td></tr>
+        <tr>
+                <td> <b>liquibaseDefaultSchemaName</b> </td>
+                <td>Default schema name for the db if it isn't defined in the uri. This defaults to None.</td>
+        </tr>
+        <tr><td></td><td>
+
+            liquibaseDefaultSchemaName := Some("my_schema")
 
         </td></tr>
         <tr>

--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,4 @@ crossScalaVersions := Seq("2.9.2", "2.10.0")
 
 libraryDependencies += "org.liquibase" % "liquibase-core" % "3.3.0"
 
-publishMavenStyle := true
-
 publishTo := Some(Resolver.file("bigtoast.github.com", file(Path.userHome + "/Projects/BigToast/bigtoast.github.com/repo")))

--- a/build.sbt
+++ b/build.sbt
@@ -5,10 +5,10 @@ organization := "com.github.bigtoast"
 
 name := "sbt-liquibase"
 
-version := "0.5"
+version := "0.6-SNAPSHOT"
 
 crossScalaVersions := Seq("2.9.2", "2.10.0")
 
-libraryDependencies += "org.liquibase" % "liquibase-core" % "2.0.5"
+libraryDependencies += "org.liquibase" % "liquibase-core" % "3.3.0"
 
-publishTo := Some(Resolver.file("bigtoast.github.com", file(Path.userHome + "/Projects/BigToast/bigtoast.github.com/repo")))
+//publishTo := Some(Resolver.file("bigtoast.github.com", file(Path.userHome + "/Projects/BigToast/bigtoast.github.com/repo")))

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,11 @@
 
 sbtPlugin := true
 
-organization := "ch.becompany"
+organization := "com.github.bigtoast"
 
 name := "sbt-liquibase"
 
-version := "0.6"
+version := "0.5"
 
 crossScalaVersions := Seq("2.9.2", "2.10.0")
 
@@ -13,12 +13,4 @@ libraryDependencies += "org.liquibase" % "liquibase-core" % "3.3.0"
 
 publishMavenStyle := true
 
-credentials += Credentials(Path.userHome / ".sbt" / ".credentials")
-
-publishTo := {
-  val nexus = "http://nexus.becompany.ch/nexus/"
-  if (isSnapshot.value)
-    Some("snapshots" at nexus + "content/repositories/snapshots") 
-  else
-    Some("releases"  at nexus + "content/repositories/releases")
-}
+publishTo := Some(Resolver.file("bigtoast.github.com", file(Path.userHome + "/Projects/BigToast/bigtoast.github.com/repo")))

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ organization := "com.github.bigtoast"
 
 name := "sbt-liquibase"
 
-version := "0.5"
+version := "0.6"
 
 crossScalaVersions := Seq("2.9.2", "2.10.0")
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,14 +1,24 @@
 
 sbtPlugin := true
 
-organization := "com.github.bigtoast"
+organization := "ch.becompany"
 
 name := "sbt-liquibase"
 
-version := "0.6-SNAPSHOT"
+version := "0.6"
 
 crossScalaVersions := Seq("2.9.2", "2.10.0")
 
 libraryDependencies += "org.liquibase" % "liquibase-core" % "3.3.0"
 
-//publishTo := Some(Resolver.file("bigtoast.github.com", file(Path.userHome + "/Projects/BigToast/bigtoast.github.com/repo")))
+publishMavenStyle := true
+
+credentials += Credentials(Path.userHome / ".sbt" / ".credentials")
+
+publishTo := {
+  val nexus = "http://nexus.becompany.ch/nexus/"
+  if (isSnapshot.value)
+    Some("snapshots" at nexus + "content/repositories/snapshots") 
+  else
+    Some("releases"  at nexus + "content/repositories/releases")
+}

--- a/src/main/scala/LiquibasePlugin.scala
+++ b/src/main/scala/LiquibasePlugin.scala
@@ -5,14 +5,14 @@ import sbt._
 import classpath._
 import Process._
 import Keys._
-
 import java.io.{File, PrintStream}
 import java.text.SimpleDateFormat
-
 import liquibase.integration.commandline.CommandLineUtils
 import liquibase.resource.FileSystemResourceAccessor
 import liquibase.database.Database
 import liquibase.Liquibase
+import liquibase.CatalogAndSchema
+import liquibase.diff.output.DiffOutputControl
 
 object LiquibasePlugin extends Plugin {
 
@@ -44,23 +44,61 @@ object LiquibasePlugin extends Plugin {
   val liquibaseUsername  = SettingKey[String]("liquibase-username", "username yo.")
   val liquibasePassword  = SettingKey[String]("liquibase-password", "password")
   val liquibaseDriver    = SettingKey[String]("liquibase-driver", "driver")
-  val liquibaseDefaultSchemaName = SettingKey[String]("liquibase-default-schema-name","default schema name")
+  val liquibaseDefaultCatalog = SettingKey[Option[String]]("liquibase-default-catalog","default catalog")
+  val liquibaseDefaultSchemaName = SettingKey[Option[String]]("liquibase-default-schema-name","default schema name")
+  val liquibaseChangelogCatalog = SettingKey[Option[String]]("liquibase-changelog-catalog", "changelog catalog")
+  val liquibaseChangelogSchemaName = SettingKey[Option[String]]("liquibase-changelog-schema-name", "changelog schema name")
   val liquibaseContext = SettingKey[String]("liquibase-context","changeSet contexts to execute")
 
   lazy val liquibaseDatabase = TaskKey[Database]("liquibase-database", "the database")
   lazy val liquibase = TaskKey[Liquibase]("liquibase", "liquibase object")
 
   lazy val liquibaseSettings :Seq[Setting[_]] = Seq[Setting[_]](
-    liquibaseDefaultSchemaName := "liquischema",
+    liquibaseDefaultCatalog := None,
+    liquibaseDefaultSchemaName := None,
+    liquibaseChangelogCatalog := None,
+    liquibaseChangelogSchemaName := None,
     liquibaseChangelog := "src/main/migrations/changelog.xml",
     liquibaseContext := "",
     //changelog <<= baseDirectory( _ / "src" / "main" / "migrations" /  "changelog.xml" absolutePath ),
 
 
-  liquibaseDatabase <<= (liquibaseUrl, liquibaseUsername, liquibasePassword, liquibaseDriver, liquibaseDefaultSchemaName, fullClasspath in Runtime ) map {
-    (url :String, uname :String, pass :String, driver :String, schemaName :String, cpath ) =>
-      //CommandLineUtils.createDatabaseObject( ClasspathUtilities.toLoader(cpath.map(_.data)) ,url, uname, pass, driver, schemaName, null,null)
-      CommandLineUtils.createDatabaseObject( ClasspathUtilities.toLoader(cpath.map(_.data)) ,url, uname, pass, driver, null, null,null)
+  liquibaseDatabase <<= (
+      liquibaseUrl,
+      liquibaseUsername,
+      liquibasePassword,
+      liquibaseDriver,
+      liquibaseDefaultCatalog,
+      liquibaseDefaultSchemaName,
+      liquibaseChangelogCatalog,
+      liquibaseChangelogSchemaName,
+      fullClasspath in Runtime
+    ) map { (
+        url,
+        uname,
+        pass,
+        driver,
+        liquibaseDefaultCatalog,
+        liquibaseDefaultSchemaName,
+        liquibaseChangelogCatalog,
+        liquibaseChangelogSchemaName,
+        cpath) =>
+      CommandLineUtils.createDatabaseObject(
+          ClasspathUtilities.toLoader(cpath.map(_.data)),
+          url,
+          uname,
+          pass,
+          driver,
+          liquibaseDefaultCatalog.getOrElse(null),
+          liquibaseDefaultSchemaName.getOrElse(null),
+          false, // outputDefaultCatalog
+          true, // outputDefaultSchema
+          null, // databaseClass
+          null, // driverPropertiesFile
+          null, // propertyProviderClass
+          liquibaseChangelogCatalog.getOrElse(null),
+          liquibaseChangelogSchemaName.getOrElse(null)
+      )
   },
 
   liquibase <<= ( liquibaseChangelog, liquibaseDatabase ) map {
@@ -73,7 +111,7 @@ object LiquibasePlugin extends Plugin {
         liquibase.update(context)
     },
 
-    liquibaseStatus <<= liquibase map { _.reportStatus(true, null, new LoggerWriter( ConsoleLogger() ) ) },
+    liquibaseStatus <<= liquibase map { _.reportStatus(true, null.asInstanceOf[String], new LoggerWriter( ConsoleLogger() ) ) },
     liquibaseClearChecksums <<= liquibase map { _.clearCheckSums() },
     liquibaseListLocks <<= (streams, liquibase) map { (out, lbase) => lbase.reportLocks( new PrintStream(out.binary()) )  },
     liquibaseReleaseLocks <<= (streams, liquibase) map { (out, lbase) => lbase.forceReleaseLocks() },
@@ -84,7 +122,7 @@ object LiquibasePlugin extends Plugin {
 
     liquibaseRollback <<= inputTask { (argTask) =>
       ( streams, liquibase, argTask ) map { ( out, lbase, args :Seq[String] ) =>
-        lbase.rollback( args.head , null )
+        lbase.rollback( args.head , null.asInstanceOf[String] )
         out.log("Rolled back to tag %s".format(args.head))
       }
     },
@@ -98,13 +136,13 @@ object LiquibasePlugin extends Plugin {
 
     liquibaseRollbackSql <<= inputTask { (argTask) =>
       ( streams, liquibase, argTask ) map { ( out, lbase, args :Seq[String] ) =>
-        lbase.rollback( args.head , null, out.text() )
+        lbase.rollback( args.head , null.asInstanceOf[String], out.text() )
       }
     },
 
     liquibaseRollbackCountSql <<= inputTask { (argTask) =>
       ( streams, liquibase, argTask ) map { ( out, lbase, args :Seq[String] ) =>
-        lbase.rollback( args.head.toInt , null, out.text() )
+        lbase.rollback( args.head.toInt , null.asInstanceOf[String], out.text() )
       }
     },
 
@@ -133,9 +171,33 @@ object LiquibasePlugin extends Plugin {
       }
     },
 
-    liquibaseGenerateChangelog <<= (streams, liquibase, liquibaseChangelog, liquibaseDefaultSchemaName, baseDirectory) map { (out, lbase, clog, sname, bdir) =>
-      //CommandLineUtils.doGenerateChangeLog(clog, lbase.getDatabase(), sname, null,null,null, bdir / "src" / "main" / "migrations" absolutePath )
-      CommandLineUtils.doGenerateChangeLog(clog, lbase.getDatabase(), null, null,null,null, bdir / "src" / "main" / "migrations" absolutePath )
+    liquibaseGenerateChangelog <<= (
+        streams,
+        liquibase,
+        liquibaseChangelog,
+        liquibaseDefaultCatalog,
+        liquibaseDefaultSchemaName,
+        liquibaseChangelogCatalog,
+        liquibaseChangelogSchemaName,
+        baseDirectory) map { (
+            out,
+            lbase,
+            clog,
+            defaultCatalog,
+            defaultSchemaName,
+            liquibaseChangelogCatalog,
+            liquibaseChangelogSchemaName,
+            bdir) =>
+      CommandLineUtils.doGenerateChangeLog(
+          clog,
+          lbase.getDatabase(),
+          defaultCatalog.getOrElse(null),
+          defaultSchemaName.getOrElse(null),
+          null, // snapshotTypes
+          null, // author
+          null, // context
+          bdir / "src" / "main" / "migrations" absolutePath,
+          new DiffOutputControl())
     },
 
     liquibaseChangelogSyncSql <<= (streams, liquibase ) map { ( out, lbase) =>


### PR DESCRIPTION
Update to Liquibase 3.3.0
Support for the following settings:
- liquibaseChangelogCatalog
- liquibaseChangelogSchemaName
- liquibaseDefaultCatalog
- liquibaseDefaultSchemaName
