### PR TITLE
Added setting for using classloader resource instead of filesystem resource for changelog

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,9 +5,9 @@ organization := "com.github.bigtoast"
 
 name := "sbt-liquibase"
 
-version := "0.5"
+version := "0.6"
 
-crossScalaVersions := Seq("2.9.2", "2.10.0")
+crossScalaVersions := Seq("2.11.0")
 
 libraryDependencies += "org.liquibase" % "liquibase-core" % "2.0.5"
 


### PR DESCRIPTION
I added a setting for using a ClassLoaderResourceAccessor instead of the FileSystemResourceAccessor since I wanted to run my migrations at application startup and have them on the classpath and the filenames in the DATABASECHANGELOG-table would not match when using the FileSystemResourceAccessor in one place and the ClassLoaderResourceAccessor in the other one.

Default value for liquibaseUseClasspathLoader is false to keep the old behaviour.
